### PR TITLE
perf: Speedup disc operations

### DIFF
--- a/source/system.f256/module.interfaces/kernel/commands/files/dir.asm
+++ b/source/system.f256/module.interfaces/kernel/commands/files/dir.asm
@@ -27,10 +27,12 @@ Command_Dir:	;; [dir]
 		bcs     _CDExit
 
 _CDEventLoop:
-		jsr     kernel.Yield        		; Polite, not actually needed.
 		jsr     GetNextEvent
-		bcs     _CDEventLoop
+		bcc     _CDProcessEvent
+		jsr     kernel.Yield        		; Polite, not actually needed.
+		bra     _CDEventLoop
 
+_CDProcessEvent
 		lda     KNLEvent.type  
 		cmp     #kernel.event.directory.CLOSED
 		beq    	_CDExit


### PR DESCRIPTION
This performance patch modifies the handling of under-disk operation kernel events: as long as events remain in the queue, the system will not yield.
Performance improvement with BLOAD from SD card is about 12x. From IEC devices I measured 3x using JiffyDOS.