### PR TITLE
chore: `common.make` -> `definitions.mk`

### DIFF
--- a/games/demo/Makefile
+++ b/games/demo/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\source\common.make
+include ..\..\source\definitions.mk
 else
-include ../../source/common.make
+include ../../source/definitions.mk
 endif
 
 LANGUAGE = en

--- a/games/demo/graphics/Makefile
+++ b/games/demo/graphics/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\..\source\common.make
+include ..\..\..\source\definitions.mk
 else
-include ../../../source/common.make
+include ../../../source/definitions.mk
 endif
 
 GRAPHICS = up:29,17 right:63,18 down:95,18 left:122,18

--- a/games/demo/upload/Makefile
+++ b/games/demo/upload/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\..\source\common.make
+include ..\..\..\source\definitions.mk
 else
-include ../../../source/common.make
+include ../../../source/definitions.mk
 endif
 
 all:

--- a/games/demo2/Makefile
+++ b/games/demo2/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\source\common.make
+include ..\..\source\definitions.mk
 else
-include ../../source/common.make
+include ../../source/definitions.mk
 endif
 
 LANGUAGE = en

--- a/games/demo2/upload/Makefile
+++ b/games/demo2/upload/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\..\source\common.make
+include ..\..\..\source\definitions.mk
 else
-include ../../../source/common.make
+include ../../../source/definitions.mk
 endif
 
 all:

--- a/games/invaders/Makefile
+++ b/games/invaders/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\source\common.make
+include ..\..\source\definitions.mk
 else
-include ../../source/common.make
+include ../../source/definitions.mk
 endif
 
 LANGUAGE = en

--- a/games/invaders/graphics/Makefile
+++ b/games/invaders/graphics/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\..\source\common.make
+include ..\..\..\source\definitions.mk
 else
-include ../../../source/common.make
+include ../../../source/definitions.mk
 endif
 
 GRAPHICS = alien11:21,16 alien12:59,11 alien21:31,50 alien22:68,50 saucer:142,42 \

--- a/games/invaders/upload/Makefile
+++ b/games/invaders/upload/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\..\source\common.make
+include ..\..\..\source\definitions.mk
 else
-include ../../../source/common.make
+include ../../../source/definitions.mk
 endif
 
 all:

--- a/games/solarfox/Makefile
+++ b/games/solarfox/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\source\common.make
+include ..\..\source\definitions.mk
 else
-include ../../source/common.make
+include ../../source/definitions.mk
 endif
 
 LANGUAGE = en

--- a/games/solarfox/graphics/Makefile
+++ b/games/solarfox/graphics/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\..\source\common.make
+include ..\..\..\source\definitions.mk
 else
-include ../../../source/common.make
+include ../../../source/definitions.mk
 endif
 
 GRAPHICS = ship:13,11 enemy:40,12 life:65,12 collect1:33,31 collect2:13,33 missile:46,31

--- a/games/solarfox/upload/Makefile
+++ b/games/solarfox/upload/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\..\source\common.make
+include ..\..\..\source\definitions.mk
 else
-include ../../../source/common.make
+include ../../../source/definitions.mk
 endif
 
 all:

--- a/games/squash/Makefile
+++ b/games/squash/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\source\common.make
+include ..\..\source\definitions.mk
 else
-include ../../source/common.make
+include ../../source/definitions.mk
 endif
 
 LANGUAGE = en

--- a/howto/Makefile
+++ b/howto/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\source\common.make
+include ..\source\definitions.mk
 else
-include ../source/common.make
+include ../source/definitions.mk
 endif
 
 all :

--- a/source/Makefile
+++ b/source/Makefile
@@ -1,9 +1,9 @@
 # Makefile for F256 SuperBASIC
 
 ifeq ($(OS),Windows_NT)
-include .\common.make
+include .\definitions.mk
 else
-include ./common.make
+include ./definitions.mk
 endif
 #
 #		Current version

--- a/source/definitions.mk
+++ b/source/definitions.mk
@@ -1,4 +1,4 @@
-#		Common command/variable definitions
+#		Shared command/variable definitions
 #
 ifeq ($(OS),Windows_NT)
 CCOPY = copy

--- a/source/modules/Makefile
+++ b/source/modules/Makefile
@@ -9,9 +9,9 @@
 # within the interpreter's memory constraints.
 
 ifeq ($(OS),Windows_NT)
-include ..\common.make
+include ..\definitions.mk
 else
-include ../common.make
+include ../definitions.mk
 endif
 
 BUILD_DIR = .build

--- a/source/modules/graphics/Makefile
+++ b/source/modules/graphics/Makefile
@@ -1,7 +1,7 @@
 ifeq ($(OS),Windows_NT)
-include ..\..\common.make
+include ..\..\definitions.mk
 else
-include ../../common.make
+include ../../definitions.mk
 endif
 
 all:

--- a/source/modules/hardware/startup/Makefile
+++ b/source/modules/hardware/startup/Makefile
@@ -1,9 +1,9 @@
 # Boot Header Data Generator
 
 ifeq ($(OS),Windows_NT)
-include ..\..\..\common.make
+include ..\..\..\definitions.mk
 else
-include ../../../common.make
+include ../../../definitions.mk
 endif
 
 INPUT_DIR = lvllvl

--- a/utility/ripgfx/Makefile
+++ b/utility/ripgfx/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\source\common.make
+include ..\..\source\definitions.mk
 else
-include ../../source/common.make
+include ../../source/definitions.mk
 endif
 
 all :

--- a/utility/spritebuild/Makefile
+++ b/utility/spritebuild/Makefile
@@ -10,9 +10,9 @@
 # ************************************************************************************************
 
 ifeq ($(OS),Windows_NT)
-include ..\..\source\common.make
+include ..\..\source\definitions.mk
 else
-include ../../source/common.make
+include ../../source/definitions.mk
 endif
 
 all :


### PR DESCRIPTION
Rename `common` to `definitions` to avoid implying that it has anything to do with the `common` subdir, switch from `.make` to `.mk` as a more standard convention for included Makefile fragments.