### PR TITLE
fix: DIR compatibility with older kernels, SAVE message and code section relief

### DIFF
--- a/source/modules/kernel/commands/files/dir.asm
+++ b/source/modules/kernel/commands/files/dir.asm
@@ -80,6 +80,7 @@ Export_DirImpl:
 		bcs     _RDExit
 
 _RDEventLoop:
+		stz 	KNLEvent.directory.file.flags ; clear for older kernels that don't set flags
 		jsr     GetNextEvent
 		bcc     _RDProcessEvent
 		jsr     kernel.Yield

--- a/source/modules/kernel/commands/files/save.asm
+++ b/source/modules/kernel/commands/files/save.asm
@@ -1,0 +1,78 @@
+; ************************************************************************************************
+; ************************************************************************************************
+;
+;		Name:		save.asm
+;		Purpose:	SAVE command implementation (slot 3 module)
+;		Created:	15th April 2026
+;		Author:		Matthias Brukner (mbrukner@gmail.com)
+;
+; ************************************************************************************************
+; ************************************************************************************************
+
+		.section code
+
+; ************************************************************************************************
+;
+;	Save the current program to disk. Called after the file has been opened
+;	for writing by the Command_Save stub (BasicFileStream is set).
+;
+; ************************************************************************************************
+
+Export_SaveImpl:
+		lda		#_CSSavingMsg & $FF
+		ldx		#_CSSavingMsg >> 8
+		jsr		PrintStringXA
+
+		.cresetcodepointer						; prepare to loop through code.
+_CSLoop:
+		.cget0									; any more?
+		beq		_CSExit
+		jsr		_CSGetCleanLine
+		sty		zTemp0+1						; save write address of data
+		sta		zTemp0
+		jsr		CLWriteByteBlock				; write the block out (main code).
+		.cnextline								; go to next line.
+		bra		_CSLoop
+
+_CSExit:
+		lda		BasicFileStream					; close file
+		jsr		KNLCloseFile
+		jsr		CLComplete						; display complete message.
+		stz		programChanged					; mark program not changed since save
+		jmp		WarmStart						; and warm start
+
+_CSSavingMsg:
+		.text	"Saving",0
+
+; ************************************************************************************************
+;
+;			Strip control codes from tokenised line, append CR, len in X
+;
+; ************************************************************************************************
+
+_CSGetCleanLine:
+		lda		#0								; no indent.
+		jsr		TKListConvertLine				; convert line into token Buffer
+
+		ldx		#0								; copy stripping controls.
+		ldy		#0
+_CSClean:
+		lda		tokenBuffer,y
+		beq		_CSDoneClean
+		bmi		_CSIgnoreCharacter
+		sta		lineBuffer,x
+		inx
+_CSIgnoreCharacter:
+		iny
+		bra		_CSClean
+_CSDoneClean:
+		lda		#13								; add CR, length now in X and ASCIIZ.
+		sta		lineBuffer,x
+		inx
+		stz		lineBuffer,x
+
+		ldy		#(lineBuffer >> 8)				; line address in YA
+		lda		#(lineBuffer & $FF)
+		rts
+
+		.send code

--- a/source/system.f256/module.interfaces/kernel/commands/files/save.asm
+++ b/source/system.f256/module.interfaces/kernel/commands/files/save.asm
@@ -2,7 +2,7 @@
 ; ************************************************************************************************
 ;
 ;		Name:		save.asm
-;		Purpose:	SAVE command
+;		Purpose:	SAVE command interface (implementation in kernel module)
 ;		Created:	31st December 2022
 ;		Reviewed: 	No
 ;		Author:		Paul Robson (paul@robsons.org.uk)
@@ -12,105 +12,53 @@
 
 ; ************************************************************************************************
 ;
-;									SAVE a Basic file
+;		SAVE a Basic file — open the file, then hand off to slot 3 module.
 ;
 ; ************************************************************************************************
 
 		.section code
 
 Command_Save: ;; [SAVE]
-		jsr 	EvaluateString 				; file name to load
-
+		jsr 	EvaluateString 				; file name
 		ldx 	zTemp0+1					; zTemp0 -> XA
-		lda 	zTemp0 
+		lda 	zTemp0
 		jsr 	KNLOpenFileWrite 			; open file for writing
-		bcs 	CSErrorHandler 				; error, so fail.
-		sta 	BasicFileStream 			; save the reading stream.
+		bcs 	_CSErrorHandler 			; error, so fail.
+		sta 	BasicFileStream 			; save the writing stream.
+		jmp 	SaveImpl 					; continue in slot 3 module
 
-		.cresetcodepointer 					; prepare to loop through code.
-_CSLoop:
-		.cget0 								; any more ?
-		beq 	_CSExit
-		jsr 	CSGetCleanLine
-		sty 	zTemp0+1 					; save write address of data
-		sta 	zTemp0
-		jsr 	CLWriteByteBlock 			; write the block out.
-		.cnextline 							; go to next line.
-		bra 	_CSLoop
-
-_CSExit:
-		lda 	BasicFileStream 			; close file
-		jsr 	KNLCloseFile
-		jsr 	CLComplete 					; display complete message.
-		stz		programChanged				; mark program not changed since save
-		jmp 	WarmStart 					; and warm start
-
-CSErrorHandler:
+_CSErrorHandler:
 		jmp 	CLErrorHandler
-
 
 ; ************************************************************************************************
 ;
 ;					Write X bytes out to BasicFileStream from zTemp0
+;					(kept in main code — shared with BSAVE)
 ;
 ; ************************************************************************************************
-		
-CLWriteByteBlock:		
-		cpx 	#0 							; written the lot ?
-		beq 	_CLWBBExit					; if so, exit
 
+CLWriteByteBlock:
+		cpx 	#0 							; written the lot?
+		beq 	_CLWBBExit					; if so, exit
 		lda 	BasicFileStream 			; stream to write, count in X
 		jsr 	KNLWriteBlock 				; call one write attempt
-		bcs 	CSErrorHandler 				; error occurred
-
+		bcs 	_CLWBBError 				; error occurred
 		sta 	zTemp1 						; save bytes written.
-
-		txa 								; subtract bytes written from X, total count.
+		txa 								; subtract bytes written from X
 		sec
 		sbc 	zTemp1
 		tax
-
-		clc 								; advance zTemp0 pointer by bytes written.
+		clc 								; advance zTemp0 pointer
 		lda 	zTemp0
 		adc 	zTemp1
 		sta 	zTemp0
 		bcc 	CLWriteByteBlock
 		inc 	zTemp0+1
-		bra 	CLWriteByteBlock 			; and retry write out.
-
+		bra 	CLWriteByteBlock
 _CLWBBExit:
 		rts
-
-; ************************************************************************************************
-;
-;					Strip control codes from tokenised line, append CR, len in X
-;
-; ************************************************************************************************
-
-CSGetCleanLine:
-		lda 	#0 							; no indent.
-		jsr 	TKListConvertLine 			; convert line into token Buffer
-
-		ldx 	#0 							; copy stripping controls.
-		ldy 	#0
-_CSClean:
-		lda 	tokenBuffer,y
-		beq 	_CSDoneClean
-		bmi 	_CSIgnoreCharacter
-		sta 	lineBuffer,x
-		inx
-_CSIgnoreCharacter:
-		iny
-		bra 	_CSClean		
-_CSDoneClean:
-		lda 	#13 						; add CR, length now in X and ASCIIZ.
-		sta 	lineBuffer,x
-		inx
-		stz 	lineBuffer,x
-
-		ldy 	#(lineBuffer >> 8) 			; line address in YA
-		lda 	#(lineBuffer & $FF) 	
-		rts
+_CLWBBError:
+		jmp 	CLErrorHandler
 
 		.send 	code
 
@@ -124,5 +72,6 @@ _CSDoneClean:
 ;		==== 			=====
 ; 		16/02/23 		Changed end to Jsr CLComplete / Jmp Warmstart as was returning to runner
 ; 						after save.
+;		15/04/26		Moved save loop, write block, and clean line to slot 3 module.
 ;
 ; ************************************************************************************************


### PR DESCRIPTION
## Summary

- **DIR on older kernels**: clear `KNLEvent.directory.file.flags` before `GetNextEvent` so stale data from previous events doesn't trigger the hidden-file filter on kernels that don't populate the flags field.
- **SAVE moved to slot 3**: the SAVE loop, write block, and line cleanup now live in a slot 3 module, freeing ~80 bytes in the main code section.
- **SAVE status message**: prints "Saving" to match LOAD's "Loading" output.