### PR TITLE
fix: DIM a(255) zero-element array and scroll-up off-by-one fill

### DIFF
--- a/source/common/commands/dim.asm
+++ b/source/common/commands/dim.asm
@@ -125,7 +125,7 @@ _DCGetSize:
 		ldx 	#0 						; get first index.
 		jsr 	Evaluate8BitInteger 	; get array dimension (Z set by lda)
 		beq 	_DCSize 				; must be 1-254
-		cmp 	#254
+		cmp 	#255 					; reject 255: size+1 wraps to 0 elements
 		beq 	_DCSize
 		rts
 

--- a/source/modules/hardware/scroll.asm
+++ b/source/modules/hardware/scroll.asm
@@ -50,11 +50,11 @@ _EXSFCopy1: 								; do one page
 
 		ldy 	EXTScreenWidth 				; blank the bottom line.
 		txa
-_EXSFFill1:	
-		dey 
-		sta 	(EXTAddress),y		
+_EXSFFill1:
+		dey
+		sta 	(EXTAddress),y
 		cpy 	#0
-		bpl 	_EXSFFill1
+		bne 	_EXSFFill1
 
 		pla 	
 		sta 	zTemp1+1


### PR DESCRIPTION
Two bug fixes found during a code audit.

## `DIM a(255)` allocated a zero-element array

The array-size guard in `_DCGetSize` (`dim.asm`) rejected 254 and allowed 255. Since the element count is computed as `size+1`, a size of 255 wraps to 0: `DIM a(255)` allocated no memory yet registered the array as valid with max index 255, so any element access silently corrupted the heap. The fix rejects 255 and allows 254.

Verified in the emulator: before, `DIM a(255)` was accepted and `a(0)=42 : PRINT a(0)` printed `0` (write lost); after, `DIM a(255)` raises "Array size", `DIM a(254)` works and stores/reads correctly, and existing sizes are unaffected.

## Scroll-up bottom-row fill wrote one byte past the screen

The bottom-line blank loop in `scroll.asm` used `bpl`, which also branches when Y reaches 0, doing one extra `dey` (Y wraps to $FF) and storing the fill byte 255 bytes past the row start. Every scroll fills both the text and colour pages, so each scroll did two stray writes into RAM beyond the visible screen. Switched to `bne`, matching the scroll-down fill loop.

Verified in the emulator: scrolling 200 lines renders cleanly with the bottom row correctly blanked.