### PR TITLE
fix: default text colour is grey instead of brown

### DIFF
--- a/source/modules/hardware/initialize.asm
+++ b/source/modules/hardware/initialize.asm
@@ -11,11 +11,11 @@
 ; Sets up screen dimensions, cursor, colors, and clears the display.
 ; This function must be called before using any other display functions.
 ;
-; \out EXTTextColour	0x52
+; \out EXTTextColour	0x12
 ; \out EXTScreenWidth	80
 ; \out EXTScreenHeight	60
 ;
-; \sideeffects	- Sets `EXTTextColour` to $52 (default color)
+; \sideeffects	- Sets `EXTTextColour` to $12 (default color)
 ;				- Sets screen dimensions to 80×60 characters
 ;				- Enables hardware cursor with character 214
 ;				- Clears screen and homes cursor
@@ -36,7 +36,7 @@ Export_EXTInitialize:
 		;
 		; Set text color
 		;
-		lda 	#$52
+		lda 	#$12 						; grey foreground on blue background
 		sta 	EXTTextColour
 
 		;


### PR DESCRIPTION
The screen initialised with a brownish default text colour. `EXTInitialize` set `EXTTextColour` to $52 — palette index 5 foreground ($874800, a brown/orange) on index 2 background (blue).

Changed to $12 so the foreground is palette index 1 ($666666, grey) on the same blue background.

Verified in the emulator: the boot prompt and typed/printed text now render grey on blue; the startup banner keeps its own colours.