### PR TITLE
mem: reserve top 4 physical pages for the NMI break monitor

### DIFF
--- a/source/system.f256/memory/memory.flat/memory.asm
+++ b/source/system.f256/memory/memory.flat/memory.asm
@@ -233,7 +233,7 @@ maxUsablePages:								; runtime max logical pages (updated by LOMEM)
 
 ProgramPage0 = BasicStart >> 13 			; physical page for slot 1 at boot (identity mapping)
 FirstFreePage = 48 							; first safe physical page for program data ($60000)
-MaxPhysPage = 64 							; 512KB = 64 × 8KB pages
+MaxPhysPage = 63 							; 64×8KB pages; page 63 ($3f) reserved for the NMI break monitor
 _AvailablePages = MaxPhysPage - FirstFreePage + 1 ; dynamic pages + page 0
 .if _AvailablePages < MaxPages
 MaxUsablePages = _AvailablePages

--- a/source/system.f256/memory/memory.flat/memory.asm
+++ b/source/system.f256/memory/memory.flat/memory.asm
@@ -233,7 +233,7 @@ maxUsablePages:								; runtime max logical pages (updated by LOMEM)
 
 ProgramPage0 = BasicStart >> 13 			; physical page for slot 1 at boot (identity mapping)
 FirstFreePage = 48 							; first safe physical page for program data ($60000)
-MaxPhysPage = 60 							; 64×8KB pages; $3d-$3f reserved for the NMI break monitor (screen save + code)
+MaxPhysPage = 59 							; highest usable 8KB page: RAM has 64 pages ($00-$3f), top 4 ($3c-$3f) reserved for the 2-bank NMI break monitor (screen save ×2 + code ×2)
 _AvailablePages = MaxPhysPage - FirstFreePage + 1 ; dynamic pages + page 0
 .if _AvailablePages < MaxPages
 MaxUsablePages = _AvailablePages

--- a/source/system.f256/memory/memory.flat/memory.asm
+++ b/source/system.f256/memory/memory.flat/memory.asm
@@ -233,7 +233,7 @@ maxUsablePages:								; runtime max logical pages (updated by LOMEM)
 
 ProgramPage0 = BasicStart >> 13 			; physical page for slot 1 at boot (identity mapping)
 FirstFreePage = 48 							; first safe physical page for program data ($60000)
-MaxPhysPage = 63 							; 64×8KB pages; page 63 ($3f) reserved for the NMI break monitor
+MaxPhysPage = 60 							; 64×8KB pages; $3d-$3f reserved for the NMI break monitor (screen save + code)
 _AvailablePages = MaxPhysPage - FirstFreePage + 1 ; dynamic pages + page 0
 .if _AvailablePages < MaxPages
 MaxUsablePages = _AvailablePages


### PR DESCRIPTION
Reserve physical memory pages `$3c-$3f` (the top 4 × 8KB banks) for a 2-bank NMI break monitor — two banks for screen save and two for the monitor code.

Lowers `MaxPhysPage` from 64 to 59 in `memory.asm`, so the dynamic program-data page allocator stops before those reserved banks. This is groundwork for the break monitor; it reduces available program memory by 5 pages (40KB).

Verified the build still assembles with no overflow.